### PR TITLE
Prettier size analysis + better file size estimate

### DIFF
--- a/saveutils/savefile/savefile.py
+++ b/saveutils/savefile/savefile.py
@@ -52,6 +52,8 @@ class SaveFile:
         """
         self.parse_time = time()
         self.data = json.loads(string)
+        self.raw_size_conversion_factor = len(json.dumps(self.data))/len(string)
+        self.logger.debug(f"dumped string is {self.raw_size_conversion_factor:.2%} different")
         self.parse_time = time() - self.parse_time
         self.logger.debug(f"Parse time: {self.parse_time}")
 


### PR DESCRIPTION
Did my best to keep these two commits precise on what they do - you should be able to cherry-pick either with no issue.

The first commit improves the size estimates by dumping each attribute to a json string before getting the length of it. This can probably be improved further by ensuring it's a UTF-8 string instead of an internal python representation, but that'll do for now.
It also gets an approximate scaling factor during save file read in order to scale down the estimate to account for the fact that `json.dumps` doesn't create the same string as is originally read from the file. (on my test files I found it to be about 15% bigger. With more test files we could hard code this.) Since there's now uncertainty, it also truncates everything to 3 significant figures.

The second commit just makes the log output more human-readable, by aligning various fields to be the same width and reducing the leader size. It also "rolls up" anything smaller than 0.005% into a single entry, since they're likely too small to matter to anyone using the tool.

The final output looks like:
```
P:\-2-\SOD-SaveUtils\
> .\saveutils\cli.py -i $save sizeanalysis
[06-01 00:07:13][tools.sizeanalysis] Analysing save file size...
[06-01 00:07:13][tools.sizeanalysis] Total save file size (APPROX): 11,100,000 bytes
[06-01 00:07:13][tools.sizeanalysis] interactables             5,370,000 bytes /  48.378%
[06-01 00:07:13][tools.sizeanalysis] citizens                  2,810,000 bytes /  25.315%
[06-01 00:07:13][tools.sizeanalysis] evidence                  1,470,000 bytes /  13.243%
[06-01 00:07:13][tools.sizeanalysis] messageThreads            1,060,000 bytes /   9.550%
[06-01 00:07:13][tools.sizeanalysis] rooms                       233,000 bytes /   2.099%
[06-01 00:07:13][tools.sizeanalysis] basicJobs                    95,900 bytes /   0.864%
[06-01 00:07:13][tools.sizeanalysis] doors                        40,500 bytes /   0.365%
[06-01 00:07:13][tools.sizeanalysis] companies                     8,190 bytes /   0.074%
[06-01 00:07:13][tools.sizeanalysis] buildings                     6,490 bytes /   0.058%
[06-01 00:07:13][tools.sizeanalysis] addresses                     5,810 bytes /   0.052%
[06-01 00:07:13][tools.sizeanalysis] footprints                    2,810 bytes /   0.025%
[06-01 00:07:13][tools.sizeanalysis] stolenItemJobs                2,740 bytes /   0.025%
[06-01 00:07:13][tools.sizeanalysis] sum of items < 0.005          5,164 bytes /   0.047%
[06-01 00:07:13][tools.sizeanalysis] NOTE: due to conversions between raw strings and python, sizes are estimates only.
```