### PR TITLE
Residence Changer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ This allows us to very easily see which sections of the save file take up the mo
 
 This tool allows a player to move his primary residence to any of his currently owned apartments.
 
-Apartments have a unique integer ID. By default, the list of IDs of the player's currently owned apartments are simply printed. and no change to residency is made. If you specify the `--set` flag, then an attempt is made to switch the primary residency of the player to the specified ID.
+Apartments have a unique integer ID. By default, the list of IDs of the player's currently owned apartments are simply printed, and no change to residency is made. If you specify the `--set` flag, then an attempt is made to switch the primary residency of the player to the specified ID.
 
 > Example:
 > - Printing the list of your owned apartments in `My Save File.sod`:
 > ```shell
 > cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence
 > ```
->> - Setting your apartment to ID 400:
+>> - Setting your primary residence to apartment ID 400:
 > ```shell
 > cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence --set 400
 > ```
@@ -146,6 +146,8 @@ Note, by default, you are charged 20cr by this tool for each permanent residence
 > ```shell
 > cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence --set 400 --cost 0
 > ```
+
+Currently, there is no way to know which ID corresponds to which apartment, although they will be stored in the list in the order that you purchased them from oldest to newest.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ This allows us to very easily see which sections of the save file take up the mo
 > cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" sizeanalysis -r
 > ```
 
+#### Residence Changer
+
+This tool allows a player to move his primary residence to any of his currently owned apartments.
+
+Apartments have a unique integer ID. By default, the list of IDs of the player's currently owned apartments are simply printed. and no change to residency is made. If you specify the `--set` flag, then an attempt is made to switch the primary residency of the player to the specified ID.
+
+> Example:
+> - Printing the list of your owned apartments in `My Save File.sod`:
+> ```shell
+> cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence
+> ```
+>> - Setting your apartment to ID 400:
+> ```shell
+> cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence --set 400
+> ```
+
+Note, by default, you are charged 20cr by this tool for each permanent residence change you make. This is meant to simulate a processing fee by City Hall. If you wish to change the fee, use the `--cost` flag.
+
+> Example:
+> - Setting your apartment to ID 280 for free:
+> ```shell
+> cli.exe -i "C:\Users\max\AppData\LocalLow\ColePowered Games\Shadows of Doubt\Save\My Save File.sod" residence --set 400 --cost 0
+> ```
+
 ## Contributing
 
 Contributions are welcome, and can be made by opening a pull request.

--- a/saveutils/cli.py
+++ b/saveutils/cli.py
@@ -7,6 +7,8 @@ from tools.playermigration import handle_subparser as playermigration_handle_sub
 from tools.playermigration import register_subparser as playermigration_register_subparser
 from tools.sizeanalysis import handle_subparser as sizeanalysis_handle_subparser
 from tools.sizeanalysis import register_subparser as sizeanalysis_register_subparser
+from tools.residencechanger import handle_subparser as residencechanger_handle_subparser
+from tools.residencechanger import register_subparser as residencechanger_register_subparser
 
 parser = argparse.ArgumentParser(prog='SaveUtils', description='Shadows of Doubt SaveUtils')
 parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging', default=False,
@@ -17,6 +19,7 @@ tools_subparser = parser.add_subparsers(title="Tools", description="Tools", dest
 cheats_register_subparser(tools_subparser)
 playermigration_register_subparser(tools_subparser)
 sizeanalysis_register_subparser(tools_subparser)
+residencechanger_register_subparser(tools_subparser)
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -33,3 +36,6 @@ if __name__ == '__main__':
 
     if args.tool in ["sizeanalysis"]:
         sizeanalysis_handle_subparser(args)
+
+    if args.tool in ["residence"]:
+        residencechanger_handle_subparser(args)

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -54,7 +54,7 @@ class ResidenceChanger:
         logger.info(f"New residence: {new_residence}")
         logger.info(f"Player owned apartments: {player_residences if len(player_residences) > 0 else "None"}")
 
-        # Important conditions to check! Do NOT attempt to swap permanent residency if these conditions are true!
+        # Important conditions to check! Do NOT attempt to swap permanent residency if any of these conditions are true!
         try:
             if new_residence not in player_residences:
                 logger.error(f"Attempting to switch residency to apartment {new_residence} NOT owned by player.")
@@ -71,11 +71,10 @@ class ResidenceChanger:
         except:
             source_save.locked = original_locked
             return
-        # We're good to go. Conditions passed.
+        # We're good to go. Conditions passed. Change the residency.
         source_save.safe_set_value("residence", new_residence)
         logger.info("Residence changed.")
         source_save.safe_set_value("money", money-cost)
-        #logger.info(f"Fee {"processed{money-cost}" if cost > 0 else "waived"}.")
         logger.info(f"Fee processed ({money-cost} remaining)" if cost > 0 else 'Fee waived')
         source_save.locked = original_locked
         source_save.save()

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -1,8 +1,5 @@
 from logging import getLogger, StreamHandler, Formatter
-from sys import getsizeof
 import locale
-import json
-import math
 
 from savefile.savefile import SaveFile
 
@@ -75,12 +72,12 @@ class ResidenceChanger:
 
         money -= cost
         source_save.safe_set_value("residence", new_residence)
-        logger.info(f"Residence changed.")
+        logger.info("Residence changed.")
         source_save.safe_set_value("money", money)
-        logger.info(f"Fee processed.")
+        logger.info(f"Fee {"processed" if cost > 0 else "waived"}.")
         source_save.locked = original_locked
         source_save.save()
-        logger.info(f"File saved.")
+        logger.info("File saved.")
 
 def register_subparser(main_subparser) -> None:
     """
@@ -97,10 +94,7 @@ def handle_subparser(args) -> None:
     :param args: The arguments
     """
     if args.tool == "residence":
-        source_save = args.save
-        target_save = SaveFile(args.output, args.verbose)
-
         if args.set:
-            ResidenceChanger.change_residence(source_save, args.set, args.cost)
+            ResidenceChanger.change_residence(args.save, args.set, args.cost)
         else:
-            ResidenceChanger.output_residencies(source_save)
+            ResidenceChanger.output_residencies(args.save)

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -85,7 +85,7 @@ def register_subparser(main_subparser) -> None:
     :param main_subparser: The main parser's subparser
     """
     residence_parser = main_subparser.add_parser("residence", help=description, description=description)
-    residence_parser.add_argument("-s", "--set", type=int, help="Set the amount of health your character has")
+    residence_parser.add_argument("-s", "--set", type=int, help="Set the player's primary residence to this ID")
     residence_parser.add_argument('-c', '--cost', type=int, default=ResidenceChanger.default_cost, help=f"Override the default cost of {ResidenceChanger.default_cost}cr for the residency change.")
 
 def handle_subparser(args) -> None:

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -54,7 +54,8 @@ class ResidenceChanger:
         logger.info(f"New residence: {new_residence}")
         logger.info(f"Player owned apartments: {player_residences if len(player_residences) > 0 else "None"}")
 
-        # Important conditions to check! Do NOT attempt to swap permanent residency if any of these conditions are true!
+        # Important conditions to check!
+        # Do NOT attempt to swap permanent residency if any of these conditions are true!
         try:
             if new_residence not in player_residences:
                 logger.error(f"Attempting to switch residency to apartment {new_residence} NOT owned by player.")
@@ -69,6 +70,9 @@ class ResidenceChanger:
                 logger.error(f"You don't have enough money to pay the fee. Balance: {money}. Cost: {cost}. Run the command again with the -c switch to override the cost.")
                 raise Exception
         except:
+            # If we are here, then one of the above conditions are met.
+            # We logged the error already.
+            # We just need to do cleanup here and return
             source_save.locked = original_locked
             return
         # We're good to go. Conditions passed. Change the residency.

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -2,7 +2,7 @@ from logging import getLogger, StreamHandler, Formatter
 import locale
 
 # Note. The import strategy is a bit inconsistent from the other tools.
-# We need it this way for PyTest to be happy. ~ BC
+# I needed it this way for PyTest to be happy in my environment. ~ BC
 from saveutils.savefile.savefile import SaveFile
 
 description = "A tool for changing one's primary residence."

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -1,0 +1,106 @@
+from logging import getLogger, StreamHandler, Formatter
+from sys import getsizeof
+import locale
+import json
+import math
+
+from savefile.savefile import SaveFile
+
+description = "A tool for changing one's primary residence."
+
+logger = getLogger(__name__)
+logger.setLevel("INFO")
+handler = StreamHandler()
+handler.setFormatter(Formatter("[%(asctime)s][%(name)s][%(levelname)s] %(message)s"))
+logger.addHandler(handler)
+locale.setlocale(locale.LC_ALL, '')
+
+class ResidenceChanger:
+    """
+    A tool for changing one's primary residence.
+    """
+    default_cost = 20
+
+    @staticmethod
+    def output_residencies(source_save : SaveFile):
+        """
+        Output the player's owned apartments
+        """
+        original_locked = source_save.locked
+        source_save.locked = True
+
+        logger.info("Looking up player owned residences...")
+        current_residence = source_save.get_residence()
+        player_residences = source_save.get_apartments_owned()
+        logger.info(f"Current residence: {current_residence}")
+        logger.info(f"Player owned apartments: {player_residences if len(player_residences) > 0 else "None"}")
+
+        source_save.locked = original_locked
+
+
+    @staticmethod
+    def change_residence(source_save : SaveFile, new_residence : int, cost : int):
+        """
+        Changes the player's residence to one available
+        """
+        original_locked = source_save.locked
+        source_save.locked = True
+
+        logger.info("Looking up player owned residences...")
+
+        money = source_save.get_money()
+        current_residence = source_save.get_residence()
+        player_residences = source_save.get_apartments_owned()
+        logger.info(f"Money: {money}")
+        logger.info(f"Cost: {cost}")
+        logger.info(f"Current residence: {current_residence}")
+        logger.info(f"New residence: {new_residence}")
+        logger.info(f"Player owned apartments: {player_residences if len(player_residences) > 0 else "None"}")
+
+        # Sanity checks
+        if new_residence not in player_residences:
+            logger.error(f"Attempting to switch residency to apartment {new_residence} NOT owned by player.")
+            return
+        if cost < 0:
+            logger.error(f"Cost override is negative ({cost}). City Hall will not pay you to switch residencies.")
+            return
+        if current_residence == new_residence:
+            logger.error(f"You already live in apartment {current_residence} as your primary residency. You don't need to switch.")
+            return
+        if cost > money:
+            logger.error(f"You don't have enough money to pay the fee. Balance: {money}. Cost: {cost}. Run the command again with the -c switch to override the cost.")
+            return
+        
+        # We're good to go
+
+        money -= cost
+        source_save.safe_set_value("residence", new_residence)
+        logger.info(f"Residence changed.")
+        source_save.safe_set_value("money", money)
+        logger.info(f"Fee processed.")
+        source_save.locked = original_locked
+        source_save.save()
+        logger.info(f"File saved.")
+
+def register_subparser(main_subparser) -> None:
+    """
+    Registers the residence changer subparser.
+    :param main_subparser: The main parser's subparser
+    """
+    residence_parser = main_subparser.add_parser("residence", help=description, description=description)
+    residence_parser.add_argument("-s", "--set", type=int, help="Set the amount of health your character has")
+    residence_parser.add_argument('-c', '--cost', type=int, default=ResidenceChanger.default_cost, help=f"Override the default cost of {ResidenceChanger.default_cost}cr for the residency change.")
+
+def handle_subparser(args) -> None:
+    """
+    Handles the residence changer subparser.
+    :param args: The arguments
+    """
+    if args.tool == "residence":
+        source_save = args.save
+        target_save = SaveFile(args.output, args.verbose)
+
+        if args.set:
+            ResidenceChanger.change_residence(source_save, args.set, args.cost)
+        else:
+            ResidenceChanger.output_residencies(source_save)

--- a/saveutils/tools/residencechanger.py
+++ b/saveutils/tools/residencechanger.py
@@ -1,7 +1,9 @@
 from logging import getLogger, StreamHandler, Formatter
 import locale
 
-from savefile.savefile import SaveFile
+# Note. The import strategy is a bit inconsistent from the other tools.
+# We need it this way for PyTest to be happy. ~ BC
+from saveutils.savefile.savefile import SaveFile
 
 description = "A tool for changing one's primary residence."
 
@@ -16,7 +18,7 @@ class ResidenceChanger:
     """
     A tool for changing one's primary residence.
     """
-    default_cost = 20
+    DEFAULT_COST = 20
 
     @staticmethod
     def output_residencies(source_save : SaveFile):
@@ -36,7 +38,7 @@ class ResidenceChanger:
 
 
     @staticmethod
-    def change_residence(source_save : SaveFile, new_residence : int, cost : int):
+    def change_residence(source_save : SaveFile, new_residence : int, cost : int = DEFAULT_COST, target_save : SaveFile = None, skipSave : bool = False):
         """
         Changes the player's residence to one available
         """
@@ -81,7 +83,8 @@ class ResidenceChanger:
         source_save.safe_set_value("money", money-cost)
         logger.info(f"Fee processed ({money-cost} remaining)" if cost > 0 else 'Fee waived')
         source_save.locked = original_locked
-        source_save.save()
+        if not skipSave: # For testing purposes, we have the option to skip writing to the file
+            source_save.save(target_save)
         logger.info("File saved.")
 
 def register_subparser(main_subparser) -> None:
@@ -91,7 +94,7 @@ def register_subparser(main_subparser) -> None:
     """
     residence_parser = main_subparser.add_parser("residence", help=description, description=description)
     residence_parser.add_argument("-s", "--set", type=int, help="Set the player's primary residence to this ID")
-    residence_parser.add_argument('-c', '--cost', type=int, default=ResidenceChanger.default_cost, help=f"Override the default cost of {ResidenceChanger.default_cost}cr for the residency change.")
+    residence_parser.add_argument('-c', '--cost', type=int, default=ResidenceChanger.DEFAULT_COST, help=f"Override the default cost of {ResidenceChanger.DEFAULT_COST}cr for the residency change.")
 
 def handle_subparser(args) -> None:
     """

--- a/tests/savefile_tests/test_residence.py
+++ b/tests/savefile_tests/test_residence.py
@@ -15,7 +15,6 @@ class TestResidenceChanger(unittest.TestCase):
     cost_free = 0
     cost_custom = 50
     original_apartment = 500
-    duplicate_apartment = 500
     nonplayer_apartment = 444
     new_apartment = 600
     owned_apartments = [500, 600, 700, 800]
@@ -32,14 +31,18 @@ class TestResidenceChanger(unittest.TestCase):
 
     def test_initialisation(self):
         """
-        Tests that the init, from_file, and from_string initialisation methods work as expected and are equivalent.
+        Tests that some of the values we're using make sense in case they get changed
         """
         self.assertLess(ResidenceChanger.DEFAULT_COST, self.default_money)
-        self.assertGreater(self.cost_excessive, self.default_money)
+        self.assertLess(self.default_money, self.cost_excessive)
+        self.assertLess(self.cost_custom, self.default_money)
+        self.assertIn(self.original_apartment, self.owned_apartments)
+        self.assertIn(self.new_apartment, self.owned_apartments)
+        self.assertNotIn(self.nonplayer_apartment, self.owned_apartments)
 
     def test_cost_excessive(self):
         """
-        Tests some methods which get save meta information.
+        Tests that we catch if the cost to change residency exceeds the player's funds
         """
         ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_excessive, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.original_apartment)
@@ -47,7 +50,7 @@ class TestResidenceChanger(unittest.TestCase):
 
     def test_cost_negative(self):
         """
-        Tests some methods which get save meta information.
+        Tests if the user is trying to pay a negative amount (ie. get money back)
         """
         ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_negative, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.original_apartment)
@@ -55,7 +58,7 @@ class TestResidenceChanger(unittest.TestCase):
 
     def test_waivefee(self):
         """
-        Tests some methods which get save meta information.
+        Tests that we can skip the fee and not get charged
         """
         ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_free, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.new_apartment)
@@ -63,7 +66,7 @@ class TestResidenceChanger(unittest.TestCase):
     
     def test_nonplayerapartment(self):
         """
-        Tests some methods which get save meta information.
+        Tests trying to claim an unowned apartment
         """
         ResidenceChanger.change_residence(self.savefile, self.nonplayer_apartment, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.original_apartment)
@@ -71,15 +74,15 @@ class TestResidenceChanger(unittest.TestCase):
     
     def test_alreadyresidency(self):
         """
-        Tests some methods which get save meta information.
+        Tests if we're trying to move to the same apartment
         """
-        ResidenceChanger.change_residence(self.savefile, self.duplicate_apartment, skipSave=True)
-        self.assertEqual(self.savefile.get_residence(), self.duplicate_apartment)
+        ResidenceChanger.change_residence(self.savefile, self.original_apartment, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.original_apartment)
         self.assertEqual(self.savefile.get_money(), self.default_money)
 
     def test_customfee(self):
         """
-        Tests some methods which get save meta information.
+        Tests adjusting the fee
         """
         ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_custom, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.new_apartment)
@@ -87,7 +90,7 @@ class TestResidenceChanger(unittest.TestCase):
 
     def test_default(self):
         """
-        Tests some methods which get save meta information.
+        Tests moving to a new apartment with the default fee
         """
         ResidenceChanger.change_residence(self.savefile, self.new_apartment, skipSave=True)
         self.assertEqual(self.savefile.get_residence(), self.new_apartment)

--- a/tests/savefile_tests/test_residence.py
+++ b/tests/savefile_tests/test_residence.py
@@ -1,0 +1,94 @@
+import unittest
+
+from saveutils.savefile.savefile import SaveFile
+from saveutils.tools.residencechanger import ResidenceChanger
+
+
+class TestResidenceChanger(unittest.TestCase):
+    """
+    Tests for the SaveFile class.
+    """
+    save_path = 'test_saves/test.sod'
+    default_money = 1000
+    cost_excessive = default_money + 1000
+    cost_negative = -500
+    cost_free = 0
+    cost_custom = 50
+    original_apartment = 500
+    duplicate_apartment = 500
+    nonplayer_apartment = 444
+    new_apartment = 600
+    owned_apartments = [500, 600, 700, 800]
+
+    def setUp(self):
+        """
+        Note, this is run before every test.
+        Large save files can take a while to load, so keep this in mind.
+        """
+        self.savefile = SaveFile.from_file(self.save_path)
+        self.savefile.set_value("residence", self.original_apartment)
+        self.savefile.set_value("apartmentsOwned", self.owned_apartments)
+        self.savefile.set_value("money", self.default_money)
+
+    def test_initialisation(self):
+        """
+        Tests that the init, from_file, and from_string initialisation methods work as expected and are equivalent.
+        """
+        self.assertLess(ResidenceChanger.DEFAULT_COST, self.default_money)
+        self.assertGreater(self.cost_excessive, self.default_money)
+
+    def test_cost_excessive(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_excessive, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.original_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money)
+
+    def test_cost_negative(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_negative, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.original_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money)
+
+    def test_waivefee(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_free, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.new_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money)
+    
+    def test_nonplayerapartment(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.nonplayer_apartment, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.original_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money)
+    
+    def test_alreadyresidency(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.duplicate_apartment, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.duplicate_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money)
+
+    def test_customfee(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.new_apartment, self.cost_custom, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.new_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money - self.cost_custom)
+
+    def test_default(self):
+        """
+        Tests some methods which get save meta information.
+        """
+        ResidenceChanger.change_residence(self.savefile, self.new_apartment, skipSave=True)
+        self.assertEqual(self.savefile.get_residence(), self.new_apartment)
+        self.assertEqual(self.savefile.get_money(), self.default_money - ResidenceChanger.DEFAULT_COST)


### PR DESCRIPTION
# Description

This change allows the player to change their primary residence to another owned apartment for the sake of easier fast travel. A service fee of 20cr is included by default to simulate a City Hall service fee, but this can be overridden with the `--cost` flag. See the README changes for examples.

## Type of change

- [✔️] New feature (non-breaking change which adds functionality)
- [✔️] This change requires a documentation update

# How Has This Been Tested?

I originally ran this against my own save since the save file included for testing doesn't have any apartments owned. For a successful update to the primary residency, the following conditions must be met:

1. The specified apartment is owned by the player.
2. The specified apartment is NOT already the player's primary residence.
3. The cost (ie. service fee) must not be negative.
4. The cost must not exceed the player's money.

I setup a PyTest test script, similar to the one that already exists for the SaveFile class. This one tests the above conditions by using the supplied test save modified in RAM to have residency information.

**Test Configuration**:
* OS: Windows 10
* IDE: VSCodium
* Python version: 3.13.1

# Checklist:

- [✔️] My code follows the style guidelines of this project
- [✔️] I have performed a self-review of my code
- [✔️] I have commented my code, particularly in hard-to-understand areas
- [✔️] My changes generate no new warnings
- [✔️] I have added tests that prove my fix is effective or that my feature works
- [✔️] New and existing unit tests pass locally with my changes
